### PR TITLE
Add 2026 dates announcement and update homepage

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -7,9 +7,9 @@ header:
   image: /assets/images/k9campout_banner.jpg
 ---
 
-K9 Campout is a human pup and handler event proudly operated by **[Undefined](http://undefined.charity)**. The event is for LGBTQ+ people who enjoy human pups and those who love them. 2025 marks the fourth year in a row for this amazing community gathering - and we look forward to seeing you all at TRC, August 15-17!
+K9 Campout is a human pup and handler event proudly operated by **[Undefined](http://undefined.charity)**. The event is for LGBTQ+ people who enjoy human pups and those who love them. **2026 marks our fifth year in a row** for this amazing community gathering — and we look forward to seeing you all at TRC, **August 14–16, 2026**!
 
-As a registered non-profit, we're committed to keeping costs low, maintaining transparency, and creating an inclusive, safe space for all attendees.
+As a registered non-profit, we're committed to keeping costs low, maintaining transparency, and creating an inclusive, safe space for all attendees. Additional 2026 event information, ticket opening details, and the full schedule will be announced soon.
 
 **Join our community:** [Telegram Channel](/telegram)
 

--- a/_posts/2026-02-20-we-have-dates-2026.md
+++ b/_posts/2026-02-20-we-have-dates-2026.md
@@ -1,0 +1,13 @@
+---
+layout: single
+title: "We Have Dates for 2026!"
+date: 2026-02-20 18:00:00 +0900
+categories: updates
+---
+Good evening everyone — today we have the pleasure of officially announcing **K9 Campout 2026**!
+
+**Dates:** Friday, August 14 – Sunday, August 16, 2026.
+
+Additional event information, ticket opening details, and the full schedule will follow soon.
+
+As always, if you have questions, please check the website or reach out to @puproar, @OllieTheDog, @Handler_Blue, @LostInTheMaze, or just ask in the channel.


### PR DESCRIPTION
### Motivation
- Announce confirmed K9 Campout 2026 dates so visitors have the event details (Aug 14–16, 2026). 
- Bring the homepage copy up to date to reflect 2026 as the fifth year and surface the new dates. 
- Notify visitors that ticket opening details and the full schedule will be published soon.

### Description
- Added a new post `_posts/2026-02-20-we-have-dates-2026.md` with the announcement content and confirmed dates. 
- Updated the homepage `_pages/index.md` hero copy to reference 2026 as the fifth year and to display `August 14–16, 2026` along with a note that ticket/schedule details are forthcoming. 
- No other content or site structure changes were made.

### Testing
- Ran `bundle install` to install dependencies and it completed successfully. 
- Ran `bundle exec jekyll build` to build the site and it completed successfully. 
- Served the generated site with `python3 -m http.server 4000 --directory _site` and captured a Playwright screenshot for visual verification, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998b1a587bc832291e6c15eec49b308)